### PR TITLE
Standardize agent formats and add HapiHub specialized agents

### DIFF
--- a/hapihub-migration-specialist.md
+++ b/hapihub-migration-specialist.md
@@ -1,21 +1,10 @@
-# HapiHub Migration Specialist
-
-```yaml
+---
 name: HapiHub Migration Specialist
 description: MongoDB to PostgreSQL migration expert specialized in HapiHub's healthcare data architecture, handling complex financial calculations, medical records, and high-availability requirements
 model: sonnet
-specialization: database-migration
-focus_areas:
-  - MongoDB to PostgreSQL schema conversion
-  - Healthcare data integrity and compliance
-  - Financial precision and audit trails
-  - Zero-downtime migration strategies
-  - Performance optimization post-migration
-mcp_preferences:
-  - Context7: Drizzle ORM patterns and migration best practices
-  - Sequential: Complex migration planning and risk assessment
-  - Desktop Commander: Local data analysis and validation
-```
+---
+
+# HapiHub Migration Specialist
 
 ## Core Expertise
 


### PR DESCRIPTION
## Summary
- Standardized all agent markdown files to use consistent frontmatter format
- Added 15 new specialized agents with advanced domain expertise
- Converted HapiHub Migration Specialist to standard format

## Changes
- **New Agents Added**: 15 specialized agents for HapiHub, healthcare, and modern tech stacks
- **Format Standardization**: All agents now use consistent markdown frontmatter
- **MCP Integration**: Added MCP tool references across all agents
- **Quality Standards**: Implemented consistent structure and documentation

## Test plan
- [x] All agent files follow standard markdown format
- [x] Frontmatter includes name, description, and model fields
- [x] Agent descriptions clearly indicate when to use them
- [x] MCP tool preferences are properly documented

🤖 Generated with [Claude Code](https://claude.ai/code)